### PR TITLE
fix signature begin determination

### DIFF
--- a/src/Timestamps.php
+++ b/src/Timestamps.php
@@ -146,7 +146,7 @@ class Timestamps
 
         // set starting position and skip past manifest length
         $pos = $match[0][1] + strlen($match[0][0]);
-        $stubEnd = $pos + $this->readUint($pos, 4);
+        $manifestEnd = $pos + 4 + $this->readUint($pos, 4);
 
         $pos += 4;
         $numFiles = $this->readUint($pos, 4);
@@ -166,7 +166,7 @@ class Timestamps
         $pos += 4 + $metadataLength;
 
         $compressedSizes = 0;
-        while ($pos < $stubEnd) {
+        while (($numFiles > 0) && ($pos < $manifestEnd - 24)) {
             $filenameLength = $this->readUint($pos, 4);
             $pos += 4 + $filenameLength;
 
@@ -187,6 +187,6 @@ class Timestamps
             throw new \LogicException('All files were not processed, something must have gone wrong');
         }
 
-        return $pos + $compressedSizes;
+        return $manifestEnd + $compressedSizes;
     }
 }


### PR DESCRIPTION
previously the begin of the signature was determined based on the stub-
length.

NOTE: determining the signature begin based on manifest parser end position
      can lead to overwriting the last byte of the last file in the phar
      with the first byte of the hash.

this ignored the size of the manifest.

fix is to take the end of the manifest which is known due to it's size
and add the compressed file sizes to it instead of adding this to the
internal position of the parser that runs only to detect the compressed
file sizes. authoritative is the manifest size.