### PR TITLE
fix little-endian endianness

### DIFF
--- a/src/Timestamps.php
+++ b/src/Timestamps.php
@@ -127,7 +127,7 @@ class Timestamps
 
     private function readUint($pos, $bytes)
     {
-        $res = unpack("L", substr($this->contents, $pos, $bytes));
+        $res = unpack('V', substr($this->contents, $pos, $bytes));
 
         return $res[1];
     }


### PR DESCRIPTION
previously the phar-utils did read the little-endian encoded values in
machine order.

this constitutes a problem on those machines which do not have
little-endian as machine order.

fix is to change from machine order to little-endian.

> All values greater than 1 byte are stored in little-endian byte order,
> with the exception of the API version, which for historical reasons is
> stored as 3 nibbles in big-endian order.

from: https://www.php.net/manual/en/phar.fileformat.phar.php