### PR TITLE
Add zizmor security analysis + dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,35 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - '.github/**.yml'
+    pull_request:
+        paths:
+            - '.github/**.yml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+              with:
+                  advanced-security: false
+                  annotations: true
+                  persona: 'pedantic'


### PR DESCRIPTION
Adds a `zizmor` GitHub Actions security-analysis workflow (matching `composer/packagist`) and a 7-day `cooldown` on the github-actions dependabot config, and hardens the existing workflows so zizmor (pedantic) passes (actions pinned to commit SHAs, concurrency limits, `persist-credentials: false` on read-only checkouts).